### PR TITLE
Removed duplicate async declaration

### DIFF
--- a/lib/markdox.js
+++ b/lib/markdox.js
@@ -9,7 +9,6 @@ var dox = require('dox')
   , version = require('../package.json').version
   , formatter = require('../lib/formatter').format
   , compiler = require('../lib/compiler').compile
-  , async = require('async')
   , fs = require('fs')
   , util = require('util')
   , ejs = require('ejs')


### PR DESCRIPTION
The `async` variable was declared twice.
